### PR TITLE
Fix error when connection is closed.

### DIFF
--- a/lib/spdy/parser.js
+++ b/lib/spdy/parser.js
@@ -185,3 +185,8 @@ Parser.prototype.parse = function() {
   // Probably we have more data buffered - so continue
   process.nextTick(this.parse.bind(this));
 };
+
+/**
+ * End of stream
+ */
+Parser.prototype.end = function() {}


### PR DESCRIPTION
Parser need an empty end() method.

François
