### PR TITLE
Piped streams are destroyed when connections are terminated.

### DIFF
--- a/lib/spdy/parser.js
+++ b/lib/spdy/parser.js
@@ -49,7 +49,7 @@ Parser.prototype.concat = function(len) {
   if (newSize < len) return new Buffer(0);
 
   if (i < total) i++;
-  
+
   // In case that we already have a chunk of needed size
   // Just return it
   if (i == 1) return buffers[0];
@@ -94,9 +94,9 @@ Parser.prototype.parse = function() {
   } else {
     headers.streamID = buffer.readUInt32(0, 'big');
   }
-  
+
   headers.flags = buffer[4];
-  
+
   var data = buffer.slice(8, 8 + headers.length);
 
   this.buffers[0] = buffer.slice(8 + headers.length);
@@ -168,4 +168,6 @@ Parser.prototype.parse = function() {
 /**
  * End of stream
  */
-Parser.prototype.end = function() {}
+Parser.prototype.end = function() {};
+
+Parser.prototype.destroy = function() {};


### PR DESCRIPTION
Just need to add an empty destroy() method to Parser.  Prevents a crash due to a "no method" error.

There are a couple of ways to trip it, but the easiest is to close the browser.
