### PR TITLE
Data compression

### DIFF
--- a/lib/spdy/response.js
+++ b/lib/spdy/response.js
@@ -10,7 +10,8 @@ var Buffer = require('buffer').Buffer,
     createControlFrame = require('../spdy').createControlFrame,
     createDataFrame = require('../spdy').createDataFrame,
     createPushStream = require('../spdy').createPushStream,
-    createParser = require('../spdy').createParser;
+    createParser = require('../spdy').createParser,
+    createZLib = require('../spdy').createZLib;
 
 /**
  * Class constructor
@@ -91,12 +92,22 @@ Response.prototype._write = function(data, encoding, fin) {
     data = new Buffer(0);
   }
 
-  var dframe = createDataFrame(this.c.zlib, {
+  var dframe = createDataFrame(this.getStreamCompressor(), {
     streamID: this.streamID,
-    flags: fin ? enums.DATA_FLAG_FIN : 0,
+    flags: fin ? enums.DATA_FLAG_FIN : enums.DATA_FLAG_COMPRESSED,
   }, Buffer.isBuffer(data) ? data : new Buffer(data, encoding));
 
   return this.c.write(dframe);
+};
+
+
+Response.prototype.getStreamCompressor = function(streamID) {
+  if (this.stream_compressor)
+    return this.stream_compressor;
+
+  this.stream_compressor = createZLib({use_dictionary: false});
+
+  return this.stream_compressor;
 };
 
 /**

--- a/lib/spdy/zlib.js
+++ b/lib/spdy/zlib.js
@@ -26,11 +26,19 @@ flatDict.write(flatDictStr, 'ascii');
 flatDict[flatDict.length - 1] = 0;
 
 var ZLib = exports.ZLib = function() {
-  this.context = new ZLibContext(flatDict);
+  var options = arguments[0] || { use_dictionary: true };
+
+  this.context = options.use_dictionary ?
+    new ZLibContext(flatDict) : new ZLibContext();
 };
 
 exports.createZLib = function() {
-  return new ZLib();
+  if (arguments.length > 0) {
+    return new ZLib(arguments[0]);
+  }
+  else {
+    return new ZLib();
+  }
 };
 
 ZLib.prototype.deflate = function(buffer) {


### PR DESCRIPTION
I believe that data compression is broken.  Thanks to some [comments from Mike Belshe](http://japhr.blogspot.com/2011/06/compressing-spdy-data-frames.html#comments), I think I have it worked out.

My main goal here was to ensure that the behavior of "new ZLib()" remained unchanged.  The implementation to achieve this could probably be cleaner.

Not sure what's up with the 2 upstream commits coming along for the ride here.  They are just a result of my resyncing my fork with idutny/node-spdy and contain no changes.
