### PR TITLE
Switch to new writeUInt32BE / readUInt32BE Buffer methods.

### DIFF
--- a/lib/spdy/parser.js
+++ b/lib/spdy/parser.js
@@ -9,6 +9,18 @@ var Buffer = require('buffer').Buffer,
 var enums = require('../spdy').enums;
 
 /**
+ * Compatibility with older versions of node
+ */
+if (!Buffer.prototype.readUInt32BE) {
+  Buffer.prototype.readUInt32BE = function(offset, noAssert) {
+    return this.readUInt32(offset, 'big');
+  };
+  Buffer.prototype.readUInt16BE = function(offset, noAssert) {
+    return this.readUInt16(offset, 'big');
+  };
+}
+
+/**
  * Class @constructor
  */
 var Parser = exports.Parser = function(zlib) {
@@ -76,7 +88,7 @@ Parser.prototype.parse = function() {
   // Headers are at least 8 bytes
   if (buffer.length < 8) return;
 
-  var len = buffer.readUInt32(4, 'big') & 0xffffff;
+  var len = buffer.readUInt32BE(4) & 0xffffff;
 
   buffer = this.concat(8 + len);
 
@@ -89,10 +101,10 @@ Parser.prototype.parse = function() {
   };
 
   if (headers.c) {
-    headers.version = buffer.readUInt16(0, 'big') & 0x7fff;
-    headers.type = buffer.readUInt16(2, 'big');
+    headers.version = buffer.readUInt16BE(0) & 0x7fff;
+    headers.type = buffer.readUInt16BE(2);
   } else {
-    headers.streamID = buffer.readUInt32(0, 'big');
+    headers.streamID = buffer.readUInt32BE(0);
   }
 
   headers.flags = buffer[4];
@@ -107,22 +119,22 @@ Parser.prototype.parse = function() {
   if (headers.c) {
     if (headers.type === enums.SYN_STREAM) {
       var parsed = {
-        streamID: data.readUInt32(0, 'big') & 0x7fffffff,
-        assocStreamID: data.readUInt32(4, 'big') & 0x7fffffff,
+        streamID: data.readUInt32BE(0) & 0x7fffffff,
+        assocStreamID: data.readUInt32BE(4) & 0x7fffffff,
         priority: (data[8] && 192) >> 6,
         nameValues: {}
       };
     }
     if (headers.type === enums.SYN_REPLY) {
       var parsed = {
-        streamID: data.readUInt32(0, 'big') & 0x7fffffff,
+        streamID: data.readUInt32BE(0) & 0x7fffffff,
         nameValues: {}
       };
     }
     if (headers.type === enums.RST_STREAM) {
       var parsed = {
-        streamID: data.readUInt32(0, 'big') & 0x7fffffff,
-        statusCode: data.readUInt32(4, 'big')
+        streamID: data.readUInt32BE(0) & 0x7fffffff,
+        statusCode: data.readUInt32BE(4)
       };
       data = parsed;
     }
@@ -140,7 +152,7 @@ Parser.prototype.parse = function() {
               name = nvs.slice(2, 2 + nameLen);
           nvs = nvs.slice(2 + nameLen);
 
-          var valueLen = nvs.readUInt16(0, 'big'),
+          var valueLen = nvs.readUInt16BE(0),
               value = nvs.slice(2, 2 + valueLen);
           nvs = nvs.slice(2 + valueLen);
 

--- a/lib/spdy/protocol.js
+++ b/lib/spdy/protocol.js
@@ -6,6 +6,21 @@ var Buffer = require('buffer').Buffer,
     enums = require('../spdy').enums;
 
 /**
+ * Compatibility with older versions of node
+ */
+if (!Buffer.prototype.writeUInt32BE) {
+  Buffer.prototype.writeUInt32BE = function(value, offset, noAssert) {
+    this.writeUInt32(value, offset, 'big');
+  };
+  Buffer.prototype.writeUInt32LE = function(value, offset, noAssert) {
+    this.writeUInt32(value, offset, 'little');
+  };
+  Buffer.prototype.writeUInt16BE = function(value, offset, noAssert) {
+    this.writeUInt16(value, offset, 'big');
+  };
+}
+
+/**
  * Create and return dataframe buffer
  */
 exports.createDataFrame = function(zlib, headers, data) {
@@ -16,7 +31,7 @@ exports.createDataFrame = function(zlib, headers, data) {
   var result = insertCommonData(headers, data, result);
 
   // Insert stream id
-  result.writeUInt32(headers.streamID & 0x7fffffff, 0, 'big');
+  result.writeUInt32BE(headers.streamID & 0x7fffffff, 0);
   return result;
 };
 
@@ -37,10 +52,10 @@ exports.createControlFrame = function(zlib, headers, data) {
   headers.version || (headers.version = 2);
 
   // Insert version
-  result.writeUInt16(headers.version | 0x8000, 0, 'big');
+  result.writeUInt16BE(headers.version | 0x8000, 0);
 
   // Insert type
-  result.writeUInt16(headers.type, 2, 'big');
+  result.writeUInt16BE(headers.type, 2);
 
   return result;
 };
@@ -69,15 +84,15 @@ exports.createSettingsFrame = function(zlib, settings) {
       buff = new Buffer(4 + 8 * keysLen);
 
   // Insert keys count
-  buff.writeUInt32(keysLen, 0, 'big');
+  buff.writeUInt32BE(keysLen, 0);
 
   keys.reduce(function(offset, key) {
     var raw_key = enums[key];
-    
-    buff.writeUInt32(raw_key & 0xffffff, offset, 'little');
+
+    buff.writeUInt32LE(raw_key & 0xffffff, offset);
 
     var value = settings[key];
-    buff.writeUInt32(value, offset + 4, 'big');
+    buff.writeUInt32BE(value, offset + 4);
 
     return offset + 8;
   }, 4);
@@ -128,7 +143,7 @@ function nvsToBuffer(zlib, headers, nvs) {
       buff = new Buffer(buffLen);
 
   // Insert nvs count
-  buff.writeUInt16(nvsCount, 0, 'big');
+  buff.writeUInt16BE(nvsCount, 0);
 
   Object.keys(nvs).filter(function(key) {
     return key && nvs[key];
@@ -136,12 +151,12 @@ function nvsToBuffer(zlib, headers, nvs) {
     var nameLen = Buffer.byteLength(key),
         valueLen = Buffer.byteLength(nvs[key].toString());
 
-    buff.writeUInt16(nameLen, prev, 'big');
+    buff.writeUInt16BE(nameLen, prev);
     buff.write(key.toString().toLowerCase(), prev + 2);
 
     prev += 2 + nameLen;
 
-    buff.writeUInt16(valueLen, prev, 'big');
+    buff.writeUInt16BE(valueLen, prev);
     buff.write(nvs[key].toString(), prev + 2);
 
     prev += 2 + valueLen;
@@ -156,7 +171,7 @@ function nvsToBuffer(zlib, headers, nvs) {
         assocStreamID = headers.assocStreamID || 0;
 
     // Insert assocStreamID for SYN_STREAM
-    buff.writeUInt32(assocStreamID & 0x7fffffff, 4, 'big');
+    buff.writeUInt32BE(assocStreamID & 0x7fffffff, 4);
 
     deflated.copy(buff, 10);
   } else {
@@ -165,7 +180,7 @@ function nvsToBuffer(zlib, headers, nvs) {
   }
 
   // Insert streamID
-  buff.writeUInt32(streamID & 0x7fffffff, 0, 'big');
+  buff.writeUInt32BE(streamID & 0x7fffffff, 0);
 
   // Insert priority
   buff[4] = (priority & 3) << 6;

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "spdy",
   "description": "Implementation of the SPDY protocol on node.js.",
-  "version": "0.1.2",
+  "version": "0.1.3",
 
   "author": "Fedor Indutny <fedor.indutny@gmail.com>",
 
@@ -9,7 +9,7 @@
     "zlibcontext": ">= 1.0.4"
   },
 
-  "engine": ["node >= 0.5.x"],
+  "engines": ["node >=0.5.0-pre <0.5.4 || >0.5.4"],
 
   "main": "./lib/spdy"
 }


### PR DESCRIPTION
Try to retain backwards compatibility, but 0.5.4 is a complete loss, so exclude it from the list of supported engines.
