### PR TITLE
Fixed bug in Connection.prototype.setDefaultTransferWindow

### DIFF
--- a/lib/spdy/server.js
+++ b/lib/spdy/server.js
@@ -276,7 +276,7 @@ Connection.prototype.write = function write(data, encoding) {
 // active streams
 //
 Connection.prototype.setDefaultTransferWindow = function(settings) {
-  if (settings.initial_window_size) {
+  if (settings && settings.initial_window_size) {
     this.transferWindowSize = settings.initial_window_size;
 
     for (var streamID in this.streams) {


### PR DESCRIPTION
Sometimes `settings` is undefined.
