### PR TITLE
Drop url header in v3

### DIFF
--- a/lib/spdy/protocol/v3/protocol.js
+++ b/lib/spdy/protocol/v3/protocol.js
@@ -43,15 +43,7 @@ protocol.parseHeaders = function parseHeaders(pairs) {
   }
 
   while(count > 0) {
-    var k = readString().replace(/^:/, ''),
-        v = readString();
-
-    headers[k] = v;
-
-    if (k === 'path') {
-      headers['url'] = v;
-    }
-
+    headers[readString().replace(/^:/, '')] = readString();
     count--;
   }
 


### PR DESCRIPTION
spdy/v3 deprecated 'url' header, in favor of explicit :scheme, :host, :path - no need to carry over the legacy header.
