### PR TITLE
Make scheduler wait for drain if connection.write() returns false.

### DIFF
--- a/lib/spdy/scheduler.js
+++ b/lib/spdy/scheduler.js
@@ -8,7 +8,7 @@ var scheduler = exports;
 function Scheduler(connection) {
   this.connection = connection;
   this.priorities = [[], [], [], [], [], [], [], []];
-  this._tickListener = null;
+  this._flush_scheduled = false;
 }
 
 //
@@ -34,27 +34,31 @@ Scheduler.prototype.schedule = function schedule(stream, data) {
 // Add .nextTick callback if not already present
 //
 Scheduler.prototype.tick = function tick() {
-  if (this._tickListener !== null) return;
-  var self = this;
-  this._tickListener = function() {
-    var priorities = self.priorities;
+  if (this._flush_scheduled) return;
+  this._flush_scheduled = true;
+  process.nextTick(this._flush.bind(this));
+};
 
-    self._tickListener = null;
-    self.priorities = [[], [], [], [], [], [], [], []];
+Scheduler.prototype._flush = function _flush() {
+  this._flush_scheduled = false;
 
-    // Run all priorities
-    for (var i = 0; i < 8; i++) {
-      for (var j = 0; j < priorities[i].length; j++) {
-        self.connection.write(
-          priorities[i][j]
-        );
+  var task, priorities = this.priorities;
+
+  priority_loop:
+  for (var i = 0; i < priorities.length; i++) {
+    while (task = priorities[i].shift()) {
+      if (task instanceof Function) {
+        // A task might be a function
+        task();
+      } else {
+        // or a chunk to be written
+        if (!this.connection.write(task)) {
+          // The buffer of the socket is full. Waiting until we can write again.
+          this._flush_scheduled = true;
+          this.connection.once('drain', this._flush.bind(this));
+          break priority_loop;
+        }
       }
     }
-  };
-
-  if (this.connection.parser.drained) {
-    process.nextTick(this._tickListener);
-  } else {
-    this.connection.parser.once('drain', this._tickListener);
   }
 };

--- a/lib/spdy/server.js
+++ b/lib/spdy/server.js
@@ -565,9 +565,8 @@ Stream.prototype._writeData = function _writeData(fin, buffer) {
         frame = this._framer.dataFrame(this.id, fin, buffer);
 
     stream.connection.scheduler.schedule(stream, frame);
+    if (fin) stream.connection.scheduler.schedule(stream, this.close.bind(this));
     stream.connection.scheduler.tick();
-
-    if (fin) this.close();
 
     this._unlock();
   });


### PR DESCRIPTION
This should enforce stream priorities better than the original scheduler in some cases.

I'll try to explain this. The current scheduler collects chunks for a short time, and then writes them to the connection stream starting with the highest priority chunk. This time frame is very short, because the scheduler uses `process.nextTick()`, so the time frame is exactly one JavaScript 'turn', or 'tick'. This makes the scheduler almost useless if the incoming chunk are coming asynchronously (imagine two streams with different priorities emitting data asynchronously: the higher priority stream won't have higher bandwidth allocated).

This patch makes the scheduler behave exactly the same until there's no congestion (there's enough bandwidth for every stream), but when there is, then it uses a different strategy. When the connection stream signals that its buffer is full (`connection.write()` returns `false`)  then we don't write any more until the there's free buffer space in the connection stream. In this time frame, there may be high or low priority incoming chunks, those are queued up. When the connection stream is ready again, the we write the higher priority chunks first etc. until we can.

Unfortunately, this is not completely stable yet. I am building a forwarding proxy (spdy on one side, http on the other) using node-spdy, and I use that for testing. I tested the patch with the latest Chrome, and the connection sometimes hangs, but could not figure out why. I am not very familiar with the node-spdy code base, so if someone could take a look at this that would be great. I would be glad to improve this patch further if you find problems.
