### PR TITLE
rename spdy-csr.pem to spdy-ca.pem in example code

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ var spdy = require('spdy'),
 var options = {
   key: fs.readFileSync(__dirname + '/keys/spdy-key.pem'),
   cert: fs.readFileSync(__dirname + '/keys/spdy-cert.pem'),
-  ca: fs.readFileSync(__dirname + '/keys/spdy-csr.pem'),
+  ca: fs.readFileSync(__dirname + '/keys/spdy-ca.pem'),
 
   // SPDY-specific options
   windowSize: 1024, // Server's window size


### PR DESCRIPTION
imho the 'ca' cert is a proof that your certificate issuer is a recognized intermediate certificate authority, and '-csr' in the filename would incorrectly hint at a Certificate Signing Request, which is something you send to your CA, not something you would use during operation.
