### PR TITLE
don't force chunked encoding on CONNECT streams

### DIFF
--- a/lib/spdy/server.js
+++ b/lib/spdy/server.js
@@ -627,7 +627,9 @@ Stream.prototype._init = function init() {
   });
 
   // Force chunked encoding
-  if (!headers['content-length'] && !headers['transfer-encoding']) {
+  if (!headers['content-length'] 
+      && !headers['transfer-encoding']
+      && headers.method != 'CONNECT') {
     req.push('Transfer-Encoding: chunked');
     this._forceChunked = true;
   }


### PR DESCRIPTION
since that doesn't actually make any sense and breaks the resulting TLS stream later.
