### PR TITLE
Fix possible TypeError on res.push when socket has been destroyed.

### DIFF
--- a/lib/spdy/response.js
+++ b/lib/spdy/response.js
@@ -93,16 +93,16 @@ exports.writeHead = function(statusCode) {
 // Initiates push stream
 //
 exports.push = function push(url, headers, priority, callback) {
-  if (this.socket._destroyed) {
-    return callback(Error('Can\'t open push stream, parent socket destroyed'));
-  }
-
   if (!callback && typeof priority === 'function') {
     callback = priority;
     priority = 0;
   }
 
   if (!callback) callback = function() {};
+  
+  if (this.socket._destroyed) {
+    return callback(Error('Can\'t open push stream, parent socket destroyed'));
+  }
 
   this.socket._lock(function() {
     var socket = this,


### PR DESCRIPTION
This manifests when a connection is immediately severed or a user spams the refresh button.

If this happens and res.push has been called without a callback or in the form (url, headers, callback), callback() is incorrectly invoked, leading to a TypeError.
