### PR TITLE
stream: _parseClientRequest should use non-greedy regex when parsing headers

### DIFF
--- a/lib/spdy/stream.js
+++ b/lib/spdy/stream.js
@@ -663,7 +663,7 @@ Stream.prototype._parseClientRequest = function parseClientRequest(data, cb) {
       return;
 
     // Normal line - `Key: Value`
-    var match = line.match(/^(.*):\s*(.*)$/);
+    var match = line.match(/^(.*?):\s*(.*)$/);
     assert(match !== null);
 
     var key = match[1].toLowerCase();

--- a/test/unit/plain-test.js
+++ b/test/unit/plain-test.js
@@ -63,4 +63,32 @@ suite('A SPDY Server / Plain', function() {
     });
     req.end();
   });
+
+  test('should handle header values with colons', function(done) {
+    var agent = spdy.createAgent({
+      host: '127.0.0.1',
+      port: PORT,
+      spdy: {
+        ssl: false,
+        plain: true
+      }
+    });
+
+    var refererValue = 'http://127.0.0.1:' + PORT + '/header-with-colon';
+
+    server.on('request', function(req) {
+      assert.equal(req.headers.referer, refererValue);
+    });
+
+    http.request({
+      path: '/',
+      method: 'GET',
+      agent: agent,
+      headers: { 'referer': refererValue }
+    }, function(res) {
+      assert.equal(res.statusCode, 200);
+      agent.close();
+      done();
+    }).end();
+  });
 });


### PR DESCRIPTION
This pull request should fix a small bug in the client code. When splitting header name and value on colon, the regex should be non-greedy to prevent problems with header values that contain colons (the referer header in my example).
