### PR TITLE
Don't close server push streams on associated stream's close.

### DIFF
--- a/lib/spdy/connection.js
+++ b/lib/spdy/connection.js
@@ -281,7 +281,6 @@ Connection.prototype._handleSynStream = function handleSynStream(frame) {
 
   // Associate streams
   if (associated) {
-    associated._spdyState.pushes.push(stream);
     stream.associated = associated;
   }
 

--- a/lib/spdy/response.js
+++ b/lib/spdy/response.js
@@ -166,7 +166,6 @@ exports.push = function push(url, headers, priority, callback) {
 
   stream.associated = socket;
   socket.connection._addStream(stream);
-  socket._spdyState.pushes.push(stream);
 
   socket._lock(function() {
     this._spdyState.framer.streamFrame(

--- a/lib/spdy/stream.js
+++ b/lib/spdy/stream.js
@@ -88,9 +88,6 @@ function Stream(connection, options) {
   // Store priority
   state.priority = options.priority;
 
-  // Array of push streams associated to that one
-  state.pushes = [];
-
   // How much data can be sent TO client before next WINDOW_UPDATE
   state.sinkSize = connection._spdyState.initialSinkSize;
   state.initialSinkSize = state.sinkSize;
@@ -369,13 +366,6 @@ Stream.prototype.destroy = function destroy(error) {
   // Just for http.js in v0.10
   this.writable = false;
   this.connection._removeStream(this);
-
-  // If client destroys connection - close stream and
-  // all associated push streams.
-  state.pushes.forEach(function(push) {
-    push.destroy(error);
-  });
-  state.pushes = [];
 
   // If stream is not finished, RST frame should be sent to notify client
   // about sudden stream termination.


### PR DESCRIPTION
Hi Fedor,

I found current code does not allow server pushes after their associated stream is closed, while it is allowed in spec.
http://www.chromium.org/spdy/spdy-protocol/spdy-protocol-draft3-1#TOC-3.3.1-Server-implementation

Could you take a look please?

Thanks!
Shuhei / nya
