### PR TITLE
Disable header compression.

### DIFF
--- a/lib/spdy/client.js
+++ b/lib/spdy/client.js
@@ -57,6 +57,11 @@ proto._init = function init() {
   }, this.options));
   state.socket = socket;
 
+  // Header compression is disabled by default in clients to prevent CRIME
+  // attacks. Don't enable it unless you know what you're doing.
+  if (this.options.spdy.headerCompression !== true)
+    this.options.spdy.headerCompression = false;
+
   // Create SPDY connection using newly created socket
   var connection = new spdy.Connection(socket,
                                        util._extend(this.options.spdy, {

--- a/lib/spdy/connection.js
+++ b/lib/spdy/connection.js
@@ -41,7 +41,7 @@ function Connection(socket, options, server) {
 
   // Various state info
   state.closed = false;
-  state.pool = spdy.zlibpool.create();
+  state.pool = spdy.zlibpool.create(options.headerCompression);
   state.counters = {
     pushCount: 0,
     streamCount: 0

--- a/lib/spdy/server.js
+++ b/lib/spdy/server.js
@@ -62,6 +62,12 @@ proto._init = function _init(base, options, handler) {
   options.ALPNProtocols = supportedProtocols;
   options.isServer = true;
 
+  // Header compression is enabled by default in servers, in contrast to clients
+  // where it is disabled to prevent CRIME attacks.
+  // See: https://groups.google.com/d/msg/spdy-dev/6mVYRv-lbuc/qGcW2ldOpt8J
+  if (options.headerCompression !== false)
+    options.headerCompression = true;
+
   state.options = options;
   state.reqHandler = handler;
 

--- a/lib/spdy/utils.js
+++ b/lib/spdy/utils.js
@@ -13,14 +13,17 @@ else
   utils.DuplexStream = stream.Duplex;
 
 //
-// ### function createDeflate ()
+// ### function createDeflate (version, compression)
+// #### @version {Number} SPDY version
+// #### @compression {Boolean} whether to enable compression
 // Creates deflate stream with SPDY dictionary
 //
-utils.createDeflate = function createDeflate(version) {
+utils.createDeflate = function createDeflate(version, compression) {
   var deflate = zlib.createDeflate({
     dictionary: spdy.protocol.dictionary[version],
     flush: zlib.Z_SYNC_FLUSH,
-    windowBits: 11
+    windowBits: 11,
+    level: compression ? zlib.Z_DEFAULT_COMPRESSION : zlib.Z_NO_COMPRESSION
   });
 
   // Define lock information early
@@ -33,7 +36,8 @@ utils.createDeflate = function createDeflate(version) {
 };
 
 //
-// ### function createInflate ()
+// ### function createInflate (version)
+// #### @version {Number} SPDY version
 // Creates inflate stream with SPDY dictionary
 //
 utils.createInflate = function createInflate(version) {

--- a/lib/spdy/zlib-pool.js
+++ b/lib/spdy/zlib-pool.js
@@ -2,10 +2,12 @@ var zlibpool = exports,
     spdy = require('../spdy');
 
 //
-// ### function Pool ()
+// ### function Pool (compression)
+// #### @compression {Boolean} whether to enable compression
 // Zlib streams pool
 //
-function Pool() {
+function Pool(compression) {
+  this.compression = compression;
   this.pool = {
     'spdy/2': [],
     'spdy/3': [],
@@ -14,11 +16,12 @@ function Pool() {
 }
 
 //
-// ### function create ()
+// ### function create (compression)
+// #### @compression {Boolean} whether to enable compression
 // Returns instance of Pool
 //
-zlibpool.create = function create() {
-  return new Pool();
+zlibpool.create = function create(compression) {
+  return new Pool(compression);
 };
 
 var x = 0;
@@ -34,7 +37,7 @@ Pool.prototype.get = function get(version, callback) {
 
     return {
       version: version,
-      deflate: spdy.utils.createDeflate(id),
+      deflate: spdy.utils.createDeflate(id, this.compression),
       inflate: spdy.utils.createInflate(id)
     };
   }


### PR DESCRIPTION
It is known that header compression leads to information leak.

See:
http://en.wikipedia.org/wiki/CRIME_(security_exploit)
https://code.google.com/p/chromium/issues/detail?id=139744
https://bugzilla.mozilla.org/show_bug.cgi?id=779413
