### PR TITLE
.travis.yml: surround node versions in quotes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: node_js
 node_js:
-  - 0.8
-  - 0.10
-  - 0.11
+  - "0.8"
+  - "0.10"
+  - "0.11"
 branches:
   only:
     - master


### PR DESCRIPTION
since it treats `0.10` as a float
