### PR TITLE
stream: add err.code for RST_STREAM

### DIFF
--- a/lib/spdy/connection.js
+++ b/lib/spdy/connection.js
@@ -213,7 +213,10 @@ Connection.prototype._handleFrame = function handleFrame(frame) {
       stream._spdyState.closedBy.them = true;
 
       // Emit error on destroy
-      stream.destroy(new Error('Received rst: ' + frame.status));
+      var err = new Error('Received rst: ' + frame.status);
+      err.code = 'RST_STREAM';
+      err.status = frame.status;
+      stream.destroy(err);
     // Respond with same PING
     } else if (frame.type === 'PING') {
       this._handlePing(frame.pingId);


### PR DESCRIPTION
not sure if this is how you'd like it. i'm also not sure how important the frame status is.

basically, i want to filter out any `RST_STREAM`s from my error logs. these aren't errors to me since i plan to have my client destroy pushes very frequently. i could search `err.message` but i don't like doing that.
