### PR TITLE
response: fix missing socket error

### DIFF
--- a/lib/spdy/response.js
+++ b/lib/spdy/response.js
@@ -1,7 +1,7 @@
 var spdy = require('../spdy'),
     utils = spdy.utils,
     http = require('http'),
-    stream = require('stream'),
+    Stream = require('stream').Stream,
     res = http.ServerResponse.prototype;
 
 //
@@ -140,10 +140,10 @@ exports.push = function push(url, headers, priority, callback) {
   if (!callback)
     callback = function() {};
 
-  if (socket._destroyed) {
-    var stub = new stream.Stream();
+  if (!socket || socket._destroyed) {
+    var stub = new Stream();
+    var err = Error('Can\'t open push stream, parent socket destroyed');
     utils.nextTick(function() {
-      var err = Error('Can\'t open push stream, parent socket destroyed');
       if (stub.listeners('error').length !== 0)
         stub.emit('error', err);
       callback(err);


### PR DESCRIPTION
not sure why this is, but sometimes `this.socket` is empty. seems like it sometimes exists on `req` but not `res`.

currently, the code is borked because you have a `stream` variable inside `.push()` as well as outside. now, the error is properly emitted.

also moved the error outside the next tick so there's a proper stack trace
