### PR TITLE
client: Added an option to disable decompression

### DIFF
--- a/lib/spdy/client.js
+++ b/lib/spdy/client.js
@@ -166,7 +166,9 @@ proto.createConnection = function createConnection(options) {
   var stream = new spdy.Stream(state.connection, {
     id: state.id,
     priority: options.priority || 7,
-    client: true
+    client: true,
+    decompress: options.spdy.decompress == undefined ? true :
+                                                       options.spdy.decompress
   });
   state.id += 2;
   state.connection._addStream(stream);

--- a/lib/spdy/stream.js
+++ b/lib/spdy/stream.js
@@ -43,6 +43,7 @@ function Stream(connection, options) {
   state.ended = false;
   state.paused = false;
   state.finishAttached = false;
+  state.decompress = options.decompress;
   state.decompressor = null;
 
   // Store id
@@ -771,7 +772,9 @@ Stream.prototype._handleResponse = function handleResponse(frame) {
   Object.keys(headers).map(function(key) {
     var val = headers[key];
 
-    if (key === 'content-encoding' && (val === 'gzip' || val === 'deflate'))
+    if (state.decompress &&
+        key === 'content-encoding' &&
+        (val === 'gzip' || val === 'deflate'))
       compression = val;
     else if (key !== 'status' && key !== 'version')
       headerList.push(key, headers[key]);


### PR DESCRIPTION
Having the spdy client to decompress streams by default is nice in most of the cases, but sometimes it can be useful to access the unaltered (and therefore uncompressed) stream.
