### PR TITLE
Plain http/1.1 fallback without ssl bug test case

### DIFF
--- a/test/server-test.js
+++ b/test/server-test.js
@@ -1,6 +1,7 @@
 var assert = require('assert');
 var tls = require('tls');
 var net = require('net');
+var http = require('http');
 var https = require('https');
 var transport = require('spdy-transport');
 var util = require('util');
@@ -426,6 +427,40 @@ describe('SPDY Server', function() {
         agent: false,
         rejectUnauthorized: false,
         NPNProtocols: [ 'http/1.1' ],
+        port: fixtures.port,
+        method: 'GET',
+        path: '/'
+      }, function(res) {
+        assert.equal(res.statusCode, 200);
+        res.resume();
+        res.on('end', function() {
+          server.close(done);
+        });
+      });
+
+      req.end();
+    });
+  });
+
+  it('should respond to http/1.1 without TLS', function(done) {
+    var server = spdy.createServer({
+      spdy: {
+        plain: true,
+        ssl: false
+      }
+    }, function(req, res) {
+      assert.equal(req.isSpdy, res.isSpdy);
+      assert.equal(req.spdyVersion, res.spdyVersion);
+      assert(!req.isSpdy);
+      assert.equal(req.spdyVersion, 1);
+
+      res.writeHead(200);
+      res.end();
+    });
+
+    server.listen(fixtures.port, function() {
+      var req = http.request({
+        agent: false,
         port: fixtures.port,
         method: 'GET',
         path: '/'


### PR DESCRIPTION
I think this is a bug with this library on node 0.10.

When using `plain: true, ssl: false`, and connecting with a client over `http/1.1`, the server should allow the connection and respond correctly.

This appears to work for node >= 0.12, but not for 0.10. Instead, 0.10 hangs and never responds.
