### PR TITLE
agent: handle connection-level errors correctly

### DIFF
--- a/lib/spdy/agent.js
+++ b/lib/spdy/agent.js
@@ -83,6 +83,7 @@ proto._getCreateSocket = function _getCreateSocket() {
 };
 
 proto._connect = function _connect(options, callback) {
+  var self = this;
   var state = this._spdyState;
 
   var protocols = state.options.protocols || [
@@ -146,6 +147,10 @@ proto._connect = function _connect(options, callback) {
       callback(new Error('Unexpected protocol: ' + protocol));
       return;
     }
+
+    connection.on('error', function(err) {
+      self.emit('error', err);
+    });
 
     if (state.options['x-forwarded-for'] !== undefined)
       connection.sendXForwardedFor(state.options['x-forwarded-for']);


### PR DESCRIPTION
The old code was missing a handler for the connection-level "error"
events. This commit adds an error-handler that re-emits the "error"
on the agent so that user-code can handle as needed.