### PR TITLE
Fix compatibility with Node.js master

### DIFF
--- a/lib/spdy/server.js
+++ b/lib/spdy/server.js
@@ -189,6 +189,8 @@ proto._onStream = function _onStream (stream) {
     socket = new net.Socket(socketOptions)
   }
 
+  socket.server = this
+
   handle.assignSocket(socket)
 
   // For v0.8


### PR DESCRIPTION
Currently tests fails on Node.js master due to this change: https://github.com/nodejs/node/pull/11926.
This patch fixes the issue by adding a `server` property to the socket.