### PR TITLE
Server forwards `ping` event from the transports Connection.

### DIFF
--- a/lib/spdy/server.js
+++ b/lib/spdy/server.js
@@ -124,6 +124,13 @@ proto._handleConnection = function _handleConnection (socket, protocol) {
     connection.start(2)
   }
 
+  // Pass the `ping` event to the server's EventEmitter as` _ping`. Pass the
+  // socket as an argument to the `_ping` event to allow identifying the
+  // connection that the ping was emitted from.
+  connection.on('ping', function () {
+    self.emit('_ping', socket)
+  })
+
   connection.on('error', function () {
     socket.destroy()
   })

--- a/test/server-test.js
+++ b/test/server-test.js
@@ -138,6 +138,14 @@ describe('SPDY Server', function () {
       }
     })
 
+    it('server should emit _ping event', function (done) {
+      server.once('_ping', function (socket) {
+        assert(socket instanceof net.Socket)
+        done()
+      })
+      client.ping()
+    })
+
     it('should process expect-continue request', function (done) {
       var stream = client.request({
         method: 'GET',


### PR DESCRIPTION
Pass the `ping` event on the transports connection to the
server's EventEmitter as the `_ping` event. The event passes
the client requests socket to allow users to identify the the
socket sending the ping request.

Note: I choose `_ping` with the underscore to identify that
the typical use case is internal and unlikely to be used. Similar
to https://github.com/spdy-http2/node-spdy/blob/master/lib/spdy/agent.js#L71