### PR TITLE
Agent emits connection level errors.

### DIFF
--- a/lib/spdy/agent.js
+++ b/lib/spdy/agent.js
@@ -94,6 +94,7 @@ proto._getCreateSocket = function _getCreateSocket () {
 }
 
 proto._connect = function _connect (options, callback) {
+  var self = this
   var state = this._spdyState
 
   var protocols = state.options.protocols || [
@@ -142,6 +143,11 @@ proto._connect = function _connect (options, callback) {
       protocol: /spdy/.test(protocol) ? 'spdy' : 'http2',
       isServer: false
     }, state.options.connection || {}))
+
+    // Pass connection level errors are passed to the agent.
+    connection.on('error', function (err) {
+      self.emit('error', err)
+    })
 
     // Set version when we are certain
     if (protocol === 'h2') {

--- a/test/client-test.js
+++ b/test/client-test.js
@@ -166,6 +166,8 @@ describe('SPDY Client', function () {
       var server
       var agent
       var hmodule
+      // The underlying spdy Connection created by the agent.
+      var connection
 
       beforeEach(function (done) {
         hmodule = plain ? http : https
@@ -192,8 +194,11 @@ describe('SPDY Client', function () {
               protocols: [ alpn ]
             }
           })
-
-          done()
+          // Once aagent has connection, keep a copy for testing.
+          agent.once('_connect', function () {
+            connection = agent._spdyState.connection
+            done()
+          })
         })
       })
 
@@ -223,6 +228,14 @@ describe('SPDY Client', function () {
           res.once('end', done)
         })
         req.end()
+      })
+
+      it('agent should emit connection level errors', function (done) {
+        agent.once('error', function (err) {
+          assert.strictEqual(err.message, 'mock error')
+          done()
+        })
+        connection.emit('error', new Error('mock error'))
       })
     })
   })


### PR DESCRIPTION
This builds on https://github.com/spdy-http2/node-spdy/pull/295 and adds a test case.

A spdy-transport/Connection is created by the Agent but no
error handler is created for that EventEmitter. Ensure the Agent
passes those errors to the Agent's EventEmitter to allow clients
to catch errors.