### PR TITLE
Removed npm version lock

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,8 +47,7 @@
     "standard": "^12.0.1"
   },
   "engines": {
-    "node": ">=6.0.0",
-    "npm": ">=6.0.0"
+    "node": ">=6.0.0"
   },
   "main": "./lib/spdy",
   "optionalDependencies": {}


### PR DESCRIPTION
Locking the npm version leads to a regression where perfectly working versions of npm lower than 6 can't install spdy@4.0.0.

This was introduced by 4209f1ff2c385cbb6a374b736088ec2c72de96ed, probably by mistake.