### PR TITLE
fix [DEP0066] warning for node > 10.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ node_js:
   - "6"
   - "8"
   - "10"
+  - "12"
 
 script:
   - npm run lint

--- a/lib/spdy/agent.js
+++ b/lib/spdy/agent.js
@@ -248,7 +248,7 @@ proto._createStream = function _createStream (req, handle) {
   return state.connection.reserveStream({
     method: req.method,
     path: req.path,
-    headers: req._headers,
+    headers: req.getHeaders ? req.getHeaders() : req._headers,
     host: state.host
   }, function (err, stream) {
     if (err) {

--- a/lib/spdy/response.js
+++ b/lib/spdy/response.js
@@ -15,7 +15,7 @@ exports.writeHead = function writeHead (statusCode, reason, obj) {
   }
   this.statusCode = statusCode
 
-  if (this._headers) {
+  if (this.getHeaders()) {
     // Slow-case: when progressive API and header fields are passed.
     if (obj) {
       var keys = Object.keys(obj)

--- a/lib/spdy/response.js
+++ b/lib/spdy/response.js
@@ -15,7 +15,7 @@ exports.writeHead = function writeHead (statusCode, reason, obj) {
   }
   this.statusCode = statusCode
 
-  var resHeaders = this.getHeaders ? this.getHeaders() : this._headers;
+  var resHeaders = this.getHeaders ? this.getHeaders() : this._headers
   if (resHeaders) {
     // Slow-case: when progressive API and header fields are passed.
     if (obj) {

--- a/lib/spdy/response.js
+++ b/lib/spdy/response.js
@@ -15,7 +15,8 @@ exports.writeHead = function writeHead (statusCode, reason, obj) {
   }
   this.statusCode = statusCode
 
-  if (this.getHeaders()) {
+  var resHeaders = res.getHeaders ? res.getHeaders() : res._headers;
+  if (resHeaders) {
     // Slow-case: when progressive API and header fields are passed.
     if (obj) {
       var keys = Object.keys(obj)

--- a/lib/spdy/response.js
+++ b/lib/spdy/response.js
@@ -15,7 +15,7 @@ exports.writeHead = function writeHead (statusCode, reason, obj) {
   }
   this.statusCode = statusCode
 
-  var resHeaders = res.getHeaders ? res.getHeaders() : res._headers;
+  var resHeaders = this.getHeaders ? this.getHeaders() : this._headers;
   if (resHeaders) {
     // Slow-case: when progressive API and header fields are passed.
     if (obj) {


### PR DESCRIPTION
Just a simple change from : `this._headers` to `this.getHeaders()` in line 18 of `response.js`. It should be enough to remove the warning `[DEP0066] DeprecationWarning: OutgoingMessage.prototype._headers is deprecated` for users of Node > 10.x