### PR TITLE
Using node-spdy to start the http2 server, some special request methods cannot be recognized. 

### DIFF
--- a/lib/spdy/server.js
+++ b/lib/spdy/server.js
@@ -264,7 +264,7 @@ proto.emit = function emit (event, req, res) {
 
   handle.assignRequest(req)
   handle.assignResponse(res)
-
+req.method=req.spdyStream.method
   return EventEmitter.prototype.emit.apply(this, arguments)
 }
 

--- a/lib/spdy/server.js
+++ b/lib/spdy/server.js
@@ -264,7 +264,7 @@ proto.emit = function emit (event, req, res) {
 
   handle.assignRequest(req)
   handle.assignResponse(res)
-req.method=req.spdyStream.method
+  req.method = req.spdyStream.method
   return EventEmitter.prototype.emit.apply(this, arguments)
 }
 


### PR DESCRIPTION
Using node-spdy to start the http2 server, some special request methods cannot be recognized. 

https://github.com/spdy-http2/node-spdy/issues/370