### PR TITLE
improvement: gets rid of deprecation warning

### DIFF
--- a/lib/spdy/response.js
+++ b/lib/spdy/response.js
@@ -15,7 +15,7 @@ exports.writeHead = function writeHead (statusCode, reason, obj) {
   }
   this.statusCode = statusCode
 
-  if (this._headers) {
+  if (this.getHeader) {
     // Slow-case: when progressive API and header fields are passed.
     if (obj) {
       var keys = Object.keys(obj)


### PR DESCRIPTION
replace ._headers with .getHeader to remove console warning: DEP0066] DeprecationWarning: OutgoingMessage.prototype._headers is deprecated