### PR TITLE
Emit connection errors as server sessionError

### DIFF
--- a/lib/spdy/server.js
+++ b/lib/spdy/server.js
@@ -124,11 +124,12 @@ proto._handleConnection = function _handleConnection (socket, protocol) {
     connection.start(2)
   }
 
-  connection.on('error', function () {
+  var self = this
+  connection.on('error', function (error) {
+    self.emit('sessionError', error, socket)
     socket.destroy()
   })
 
-  var self = this
   connection.on('stream', function (stream) {
     self._onStream(stream)
   })


### PR DESCRIPTION
Super tiny PR that fixes #374.

This doesn't expose all errors, there's definitely more that could be done here, but this is an easy useful addition imo.

It doesn't match up that closely to the node API, not sure how important that is to you, but it's broadly similar. The equivalent node `sessionError` event is [emitted](https://github.com/nodejs/node/blob/f1ae7ea343020f608fdc1ca77d9cdfe2c093ac72/lib/internal/http2/core.js#L2806) with the error and the session, not the socket, the error code etc values are different, and I expect it's not emitted in exactly the same cases.