### PR TITLE
Apply change from v11.10.0, v10.17.0

### DIFF
--- a/lib/spdy/response.js
+++ b/lib/spdy/response.js
@@ -57,6 +57,8 @@ exports.writeHead = function writeHead (statusCode, reason, obj) {
   this._headerSent = true
 
   if (this.socket._handle) { this.socket._handle._spdyState.stream.respond(this.statusCode, headers) }
+
+  return this;
 }
 
 exports.end = function end (data, encoding, callback) {


### PR DESCRIPTION
Return this from writeHead() to allow chaining with end().
Source: https://nodejs.org/api/http.html#http_response_writehead_statuscode_statusmessage_headers